### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@typescript-eslint/parser": "^8.16.0",
     "aws-cdk": "2.171.1",
     "cdk-dia": "^0.11.0",
-    "cdk-nag": "^2.34.11",
+    "cdk-nag": "^2.34.12",
     "esbuild": "^0.24.0",
     "eslint": "^9.16.0",
     "eslint-plugin-import": "^2.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^0.11.0
         version: 0.11.0(@aws-cdk/cloud-assembly-schema@38.0.1)(@aws-cdk/cx-api@1.204.0(@aws-cdk/cloud-assembly-schema@38.0.1))(@aws-cdk/region-info@1.204.0)(constructs@10.4.2)
       cdk-nag:
-        specifier: ^2.34.11
-        version: 2.34.11(aws-cdk-lib@2.171.1(constructs@10.4.2))(constructs@10.4.2)
+        specifier: ^2.34.12
+        version: 2.34.12(aws-cdk-lib@2.171.1(constructs@10.4.2))(constructs@10.4.2)
       esbuild:
         specifier: ^0.24.0
         version: 0.24.0
@@ -1334,8 +1334,8 @@ packages:
   '@udondan/common-substrings@3.0.2':
     resolution: {integrity: sha512-Sc8lNnubj2NtH6zj13K8ADohTnwvXBSp6NWV0LDvia/xfIGHvOhKOHjL7AM9+5lVL3LcIHl85mwpn9LYYhyxuw==}
 
-  '@vitest/eslint-plugin@1.1.12':
-    resolution: {integrity: sha512-iv9K9fz9qRxBo9J/PGSMcLdOFIKqtFZ6THqSVG/jW8CJZFkIWLxPduCTXkbyG6FNKgL49fkv348nSgmfqCU6FA==}
+  '@vitest/eslint-plugin@1.1.13':
+    resolution: {integrity: sha512-oabbCT4fCQfmFNtH2UuDfHx1d7dzi+VD3qwCpBfECfyzQq/Re9u7qTtE2WqV/hAuAOALw3ZVRiub2mXmpTyn/Q==}
     peerDependencies:
       '@typescript-eslint/utils': '>= 8.0'
       eslint: '>= 8.57.0'
@@ -1584,8 +1584,8 @@ packages:
       aws-cdk-lib: ^2.0.0
       constructs: ^10.0.0
 
-  cdk-nag@2.34.11:
-    resolution: {integrity: sha512-7lSNzIDumnVsBAM2Sor6fjPBREHf01ZXUJLHuzt5Pu1xjVAqYBEkplBOSfI0K3576L4TXIlE2nTdaGDu0+sGQA==}
+  cdk-nag@2.34.12:
+    resolution: {integrity: sha512-81Be6u+MXA0vbR0TfSCkw5OSoYSZK/7WMZUjF/0nRqc7q1fLLpwetEaNUU7xsx1j97aIIN0ehH5NOXtbA0k7tQ==}
     peerDependencies:
       aws-cdk-lib: ^2.156.0
       constructs: ^10.0.5
@@ -3754,7 +3754,7 @@ snapshots:
       '@stylistic/eslint-plugin': 2.11.0(eslint@9.16.0)(typescript@5.7.2)
       '@typescript-eslint/eslint-plugin': 8.16.0(@typescript-eslint/parser@8.16.0(eslint@9.16.0)(typescript@5.7.2))(eslint@9.16.0)(typescript@5.7.2)
       '@typescript-eslint/parser': 8.16.0(eslint@9.16.0)(typescript@5.7.2)
-      '@vitest/eslint-plugin': 1.1.12(@typescript-eslint/utils@8.16.0(eslint@9.16.0)(typescript@5.7.2))(eslint@9.16.0)(typescript@5.7.2)
+      '@vitest/eslint-plugin': 1.1.13(@typescript-eslint/utils@8.16.0(eslint@9.16.0)(typescript@5.7.2))(eslint@9.16.0)(typescript@5.7.2)
       eslint: 9.16.0
       eslint-config-flat-gitignore: 0.3.0(eslint@9.16.0)
       eslint-flat-config-utils: 0.4.0
@@ -5525,7 +5525,7 @@ snapshots:
 
   '@udondan/common-substrings@3.0.2': {}
 
-  '@vitest/eslint-plugin@1.1.12(@typescript-eslint/utils@8.16.0(eslint@9.16.0)(typescript@5.7.2))(eslint@9.16.0)(typescript@5.7.2)':
+  '@vitest/eslint-plugin@1.1.13(@typescript-eslint/utils@8.16.0(eslint@9.16.0)(typescript@5.7.2))(eslint@9.16.0)(typescript@5.7.2)':
     dependencies:
       '@typescript-eslint/utils': 8.16.0(eslint@9.16.0)(typescript@5.7.2)
       eslint: 9.16.0
@@ -5852,7 +5852,7 @@ snapshots:
       constructs: 10.4.2
       regex-parser: 2.3.0
 
-  cdk-nag@2.34.11(aws-cdk-lib@2.171.1(constructs@10.4.2))(constructs@10.4.2):
+  cdk-nag@2.34.12(aws-cdk-lib@2.171.1(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
       aws-cdk-lib: 2.171.1(constructs@10.4.2)
       constructs: 10.4.2


### PR DESCRIPTION
Upgrades project dependencies. The following changes were made:
```diff
diff --git a/package.json b/package.json
index bd4775f..1110707 100644
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@typescript-eslint/parser": "^8.16.0",
     "aws-cdk": "2.171.1",
     "cdk-dia": "^0.11.0",
-    "cdk-nag": "^2.34.11",
+    "cdk-nag": "^2.34.12",
     "esbuild": "^0.24.0",
     "eslint": "^9.16.0",
     "eslint-plugin-import": "^2.31.0",
diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
index 6fb3864..f0310d4 100644
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^0.11.0
         version: 0.11.0(@aws-cdk/cloud-assembly-schema@38.0.1)(@aws-cdk/cx-api@1.204.0(@aws-cdk/cloud-assembly-schema@38.0.1))(@aws-cdk/region-info@1.204.0)(constructs@10.4.2)
       cdk-nag:
-        specifier: ^2.34.11
-        version: 2.34.11(aws-cdk-lib@2.171.1(constructs@10.4.2))(constructs@10.4.2)
+        specifier: ^2.34.12
+        version: 2.34.12(aws-cdk-lib@2.171.1(constructs@10.4.2))(constructs@10.4.2)
       esbuild:
         specifier: ^0.24.0
         version: 0.24.0
@@ -1334,8 +1334,8 @@ packages:
   '@udondan/common-substrings@3.0.2':
     resolution: {integrity: sha512-Sc8lNnubj2NtH6zj13K8ADohTnwvXBSp6NWV0LDvia/xfIGHvOhKOHjL7AM9+5lVL3LcIHl85mwpn9LYYhyxuw==}
 
-  '@vitest/eslint-plugin@1.1.12':
-    resolution: {integrity: sha512-iv9K9fz9qRxBo9J/PGSMcLdOFIKqtFZ6THqSVG/jW8CJZFkIWLxPduCTXkbyG6FNKgL49fkv348nSgmfqCU6FA==}
+  '@vitest/eslint-plugin@1.1.13':
+    resolution: {integrity: sha512-oabbCT4fCQfmFNtH2UuDfHx1d7dzi+VD3qwCpBfECfyzQq/Re9u7qTtE2WqV/hAuAOALw3ZVRiub2mXmpTyn/Q==}
     peerDependencies:
       '@typescript-eslint/utils': '>= 8.0'
       eslint: '>= 8.57.0'
@@ -1584,8 +1584,8 @@ packages:
       aws-cdk-lib: ^2.0.0
       constructs: ^10.0.0
 
-  cdk-nag@2.34.11:
-    resolution: {integrity: sha512-7lSNzIDumnVsBAM2Sor6fjPBREHf01ZXUJLHuzt5Pu1xjVAqYBEkplBOSfI0K3576L4TXIlE2nTdaGDu0+sGQA==}
+  cdk-nag@2.34.12:
+    resolution: {integrity: sha512-81Be6u+MXA0vbR0TfSCkw5OSoYSZK/7WMZUjF/0nRqc7q1fLLpwetEaNUU7xsx1j97aIIN0ehH5NOXtbA0k7tQ==}
     peerDependencies:
       aws-cdk-lib: ^2.156.0
       constructs: ^10.0.5
@@ -3754,7 +3754,7 @@ snapshots:
       '@stylistic/eslint-plugin': 2.11.0(eslint@9.16.0)(typescript@5.7.2)
       '@typescript-eslint/eslint-plugin': 8.16.0(@typescript-eslint/parser@8.16.0(eslint@9.16.0)(typescript@5.7.2))(eslint@9.16.0)(typescript@5.7.2)
       '@typescript-eslint/parser': 8.16.0(eslint@9.16.0)(typescript@5.7.2)
-      '@vitest/eslint-plugin': 1.1.12(@typescript-eslint/utils@8.16.0(eslint@9.16.0)(typescript@5.7.2))(eslint@9.16.0)(typescript@5.7.2)
+      '@vitest/eslint-plugin': 1.1.13(@typescript-eslint/utils@8.16.0(eslint@9.16.0)(typescript@5.7.2))(eslint@9.16.0)(typescript@5.7.2)
       eslint: 9.16.0
       eslint-config-flat-gitignore: 0.3.0(eslint@9.16.0)
       eslint-flat-config-utils: 0.4.0
@@ -5525,7 +5525,7 @@ snapshots:
 
   '@udondan/common-substrings@3.0.2': {}
 
-  '@vitest/eslint-plugin@1.1.12(@typescript-eslint/utils@8.16.0(eslint@9.16.0)(typescript@5.7.2))(eslint@9.16.0)(typescript@5.7.2)':
+  '@vitest/eslint-plugin@1.1.13(@typescript-eslint/utils@8.16.0(eslint@9.16.0)(typescript@5.7.2))(eslint@9.16.0)(typescript@5.7.2)':
     dependencies:
       '@typescript-eslint/utils': 8.16.0(eslint@9.16.0)(typescript@5.7.2)
       eslint: 9.16.0
@@ -5852,7 +5852,7 @@ snapshots:
       constructs: 10.4.2
       regex-parser: 2.3.0
 
-  cdk-nag@2.34.11(aws-cdk-lib@2.171.1(constructs@10.4.2))(constructs@10.4.2):
+  cdk-nag@2.34.12(aws-cdk-lib@2.171.1(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
       aws-cdk-lib: 2.171.1(constructs@10.4.2)
       constructs: 10.4.2
```