### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@typescript-eslint/parser": "^8.17.0",
     "aws-cdk": "2.172.0",
     "cdk-dia": "^0.11.0",
-    "cdk-nag": "^2.34.18",
+    "cdk-nag": "^2.34.19",
     "esbuild": "^0.24.0",
     "eslint": "^9.16.0",
     "eslint-plugin-import": "^2.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^0.11.0
         version: 0.11.0(@aws-cdk/cloud-assembly-schema@38.0.1)(@aws-cdk/cx-api@1.204.0(@aws-cdk/cloud-assembly-schema@38.0.1))(@aws-cdk/region-info@1.204.0)(constructs@10.4.2)
       cdk-nag:
-        specifier: ^2.34.18
-        version: 2.34.18(aws-cdk-lib@2.172.0(constructs@10.4.2))(constructs@10.4.2)
+        specifier: ^2.34.19
+        version: 2.34.19(aws-cdk-lib@2.172.0(constructs@10.4.2))(constructs@10.4.2)
       esbuild:
         specifier: ^0.24.0
         version: 0.24.0
@@ -1588,8 +1588,8 @@ packages:
       aws-cdk-lib: ^2.0.0
       constructs: ^10.0.0
 
-  cdk-nag@2.34.18:
-    resolution: {integrity: sha512-Sg6eQ6C+WGTutdy5zw80tdevVZDcK50zijz7DFAOpb6gFeTl2/YsPH/YgQFMuX3Au/RfHRhhQadkh2GUdSpAxA==}
+  cdk-nag@2.34.19:
+    resolution: {integrity: sha512-UkcVcVWLpJGImyHK+R5CIUC7MPCNKVcXDhHlrRYYd9bHq3yj/XjK/y+NgmFKcFDpjXPxQ9GkEmJz/rLD67kivw==}
     peerDependencies:
       aws-cdk-lib: ^2.156.0
       constructs: ^10.0.5
@@ -5868,7 +5868,7 @@ snapshots:
       constructs: 10.4.2
       regex-parser: 2.3.0
 
-  cdk-nag@2.34.18(aws-cdk-lib@2.172.0(constructs@10.4.2))(constructs@10.4.2):
+  cdk-nag@2.34.19(aws-cdk-lib@2.172.0(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
       aws-cdk-lib: 2.172.0(constructs@10.4.2)
       constructs: 10.4.2


### PR DESCRIPTION
Upgrades project dependencies. The following changes were made:
```diff
diff --git a/package.json b/package.json
index 2152dfc..e633aec 100644
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@typescript-eslint/parser": "^8.17.0",
     "aws-cdk": "2.172.0",
     "cdk-dia": "^0.11.0",
-    "cdk-nag": "^2.34.18",
+    "cdk-nag": "^2.34.19",
     "esbuild": "^0.24.0",
     "eslint": "^9.16.0",
     "eslint-plugin-import": "^2.31.0",
diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
index 15be18d..c7ac7cf 100644
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^0.11.0
         version: 0.11.0(@aws-cdk/cloud-assembly-schema@38.0.1)(@aws-cdk/cx-api@1.204.0(@aws-cdk/cloud-assembly-schema@38.0.1))(@aws-cdk/region-info@1.204.0)(constructs@10.4.2)
       cdk-nag:
-        specifier: ^2.34.18
-        version: 2.34.18(aws-cdk-lib@2.172.0(constructs@10.4.2))(constructs@10.4.2)
+        specifier: ^2.34.19
+        version: 2.34.19(aws-cdk-lib@2.172.0(constructs@10.4.2))(constructs@10.4.2)
       esbuild:
         specifier: ^0.24.0
         version: 0.24.0
@@ -1588,8 +1588,8 @@ packages:
       aws-cdk-lib: ^2.0.0
       constructs: ^10.0.0
 
-  cdk-nag@2.34.18:
-    resolution: {integrity: sha512-Sg6eQ6C+WGTutdy5zw80tdevVZDcK50zijz7DFAOpb6gFeTl2/YsPH/YgQFMuX3Au/RfHRhhQadkh2GUdSpAxA==}
+  cdk-nag@2.34.19:
+    resolution: {integrity: sha512-UkcVcVWLpJGImyHK+R5CIUC7MPCNKVcXDhHlrRYYd9bHq3yj/XjK/y+NgmFKcFDpjXPxQ9GkEmJz/rLD67kivw==}
     peerDependencies:
       aws-cdk-lib: ^2.156.0
       constructs: ^10.0.5
@@ -5868,7 +5868,7 @@ snapshots:
       constructs: 10.4.2
       regex-parser: 2.3.0
 
-  cdk-nag@2.34.18(aws-cdk-lib@2.172.0(constructs@10.4.2))(constructs@10.4.2):
+  cdk-nag@2.34.19(aws-cdk-lib@2.172.0(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
       aws-cdk-lib: 2.172.0(constructs@10.4.2)
       constructs: 10.4.2
```