### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/node": "22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",
-    "aws-cdk": "2.173.0",
+    "aws-cdk": "2.173.1",
     "cdk-dia": "^0.11.0",
     "cdk-nag": "^2.34.23",
     "esbuild": "^0.24.0",
@@ -29,7 +29,7 @@
   "dependencies": {
     "@aws-sdk/client-organizations": "^3.712.0",
     "@aws-sdk/client-s3": "^3.712.0",
-    "aws-cdk-lib": "2.173.0",
+    "aws-cdk-lib": "2.173.1",
     "aws-lambda": "^1.0.7",
     "aws-sdk": "^2.1692.0",
     "axios": "^1.7.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.712.0
         version: 3.712.0
       aws-cdk-lib:
-        specifier: 2.173.0
-        version: 2.173.0(constructs@10.4.2)
+        specifier: 2.173.1
+        version: 2.173.1(constructs@10.4.2)
       aws-lambda:
         specifier: ^1.0.7
         version: 1.0.7
@@ -28,13 +28,13 @@ importers:
         version: 1.7.9
       cdk-iam-floyd:
         specifier: ^0.658.0
-        version: 0.658.0(aws-cdk-lib@2.173.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 0.658.0(aws-cdk-lib@2.173.1(constructs@10.4.2))(constructs@10.4.2)
       constructs:
         specifier: ^10.4.2
         version: 10.4.2
       p6-cdk-namer:
         specifier: ^1.3.1
-        version: 1.3.1(aws-cdk-lib@2.173.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 1.3.1(aws-cdk-lib@2.173.1(constructs@10.4.2))(constructs@10.4.2)
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -64,14 +64,14 @@ importers:
         specifier: ^8.18.0
         version: 8.18.0(eslint@9.17.0)(typescript@5.7.2)
       aws-cdk:
-        specifier: 2.173.0
-        version: 2.173.0
+        specifier: 2.173.1
+        version: 2.173.1
       cdk-dia:
         specifier: ^0.11.0
         version: 0.11.0(@aws-cdk/cloud-assembly-schema@38.0.1)(@aws-cdk/cx-api@1.204.0(@aws-cdk/cloud-assembly-schema@38.0.1))(@aws-cdk/region-info@1.204.0)(constructs@10.4.2)
       cdk-nag:
         specifier: ^2.34.23
-        version: 2.34.23(aws-cdk-lib@2.173.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.34.23(aws-cdk-lib@2.173.1(constructs@10.4.2))(constructs@10.4.2)
       esbuild:
         specifier: ^0.24.0
         version: 0.24.0
@@ -1434,8 +1434,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-cdk-lib@2.173.0:
-    resolution: {integrity: sha512-Da1JUwG8eL+chRSB+c2I4dRf54DWe/wmWKj9CBthNdsE9XCB8odyEcMpmgBC+R160o7ioYY2DBsAaKIIRa9XQw==}
+  aws-cdk-lib@2.173.1:
+    resolution: {integrity: sha512-xlbom4s3sbJDoHzIQmvunTufDQoJHQK8PTh653TE3338PysMX3liZ7efET9/FSQn50S2U3nINDGhrMvjkMBoKw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
@@ -1452,8 +1452,8 @@ packages:
       - yaml
       - mime-types
 
-  aws-cdk@2.173.0:
-    resolution: {integrity: sha512-riRGKSo5dzB0MSbdkZwXRC2t//dI220bgEUfVISilcEafBKj+BPzFBd/eNKuP/dEaS31njkCwtYrS7V7/lV4hQ==}
+  aws-cdk@2.173.1:
+    resolution: {integrity: sha512-1KWz6ZPPpBk3LyxE+iR4Gi1bbdY5N6Zj7kx/26jqvavBfZle93vT3M0jlTKI6v/bBtpYsVHTOmPFcq0fg1DfCw==}
     engines: {node: '>= 14.15.0'}
     hasBin: true
 
@@ -5680,7 +5680,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  aws-cdk-lib@2.173.0(constructs@10.4.2):
+  aws-cdk-lib@2.173.1(constructs@10.4.2):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.214
       '@aws-cdk/asset-kubectl-v20': 2.1.3
@@ -5688,7 +5688,7 @@ snapshots:
       '@aws-cdk/cloud-assembly-schema': 38.0.1
       constructs: 10.4.2
 
-  aws-cdk@2.173.0:
+  aws-cdk@2.173.1:
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -5868,16 +5868,16 @@ snapshots:
       - '@aws-cdk/region-info'
       - constructs
 
-  cdk-iam-floyd@0.658.0(aws-cdk-lib@2.173.0(constructs@10.4.2))(constructs@10.4.2):
+  cdk-iam-floyd@0.658.0(aws-cdk-lib@2.173.1(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
       '@udondan/common-substrings': 3.0.2
-      aws-cdk-lib: 2.173.0(constructs@10.4.2)
+      aws-cdk-lib: 2.173.1(constructs@10.4.2)
       constructs: 10.4.2
       regex-parser: 2.3.0
 
-  cdk-nag@2.34.23(aws-cdk-lib@2.173.0(constructs@10.4.2))(constructs@10.4.2):
+  cdk-nag@2.34.23(aws-cdk-lib@2.173.1(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.0(constructs@10.4.2)
+      aws-cdk-lib: 2.173.1(constructs@10.4.2)
       constructs: 10.4.2
 
   chalk@4.1.2:
@@ -7815,9 +7815,9 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  p6-cdk-namer@1.3.1(aws-cdk-lib@2.173.0(constructs@10.4.2))(constructs@10.4.2):
+  p6-cdk-namer@1.3.1(aws-cdk-lib@2.173.1(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.0(constructs@10.4.2)
+      aws-cdk-lib: 2.173.1(constructs@10.4.2)
       constructs: 10.4.2
 
   package-manager-detector@0.2.7: {}


### PR DESCRIPTION
Upgrades project dependencies. The following changes were made:
```diff
diff --git a/package.json b/package.json
index a336032..3485ff0 100644
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/node": "22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",
-    "aws-cdk": "2.173.0",
+    "aws-cdk": "2.173.1",
     "cdk-dia": "^0.11.0",
     "cdk-nag": "^2.34.23",
     "esbuild": "^0.24.0",
@@ -29,7 +29,7 @@
   "dependencies": {
     "@aws-sdk/client-organizations": "^3.712.0",
     "@aws-sdk/client-s3": "^3.712.0",
-    "aws-cdk-lib": "2.173.0",
+    "aws-cdk-lib": "2.173.1",
     "aws-lambda": "^1.0.7",
     "aws-sdk": "^2.1692.0",
     "axios": "^1.7.9",
diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
index 7ecb1d2..44ce077 100644
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.712.0
         version: 3.712.0
       aws-cdk-lib:
-        specifier: 2.173.0
-        version: 2.173.0(constructs@10.4.2)
+        specifier: 2.173.1
+        version: 2.173.1(constructs@10.4.2)
       aws-lambda:
         specifier: ^1.0.7
         version: 1.0.7
@@ -28,13 +28,13 @@ importers:
         version: 1.7.9
       cdk-iam-floyd:
         specifier: ^0.658.0
-        version: 0.658.0(aws-cdk-lib@2.173.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 0.658.0(aws-cdk-lib@2.173.1(constructs@10.4.2))(constructs@10.4.2)
       constructs:
         specifier: ^10.4.2
         version: 10.4.2
       p6-cdk-namer:
         specifier: ^1.3.1
-        version: 1.3.1(aws-cdk-lib@2.173.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 1.3.1(aws-cdk-lib@2.173.1(constructs@10.4.2))(constructs@10.4.2)
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -64,14 +64,14 @@ importers:
         specifier: ^8.18.0
         version: 8.18.0(eslint@9.17.0)(typescript@5.7.2)
       aws-cdk:
-        specifier: 2.173.0
-        version: 2.173.0
+        specifier: 2.173.1
+        version: 2.173.1
       cdk-dia:
         specifier: ^0.11.0
         version: 0.11.0(@aws-cdk/cloud-assembly-schema@38.0.1)(@aws-cdk/cx-api@1.204.0(@aws-cdk/cloud-assembly-schema@38.0.1))(@aws-cdk/region-info@1.204.0)(constructs@10.4.2)
       cdk-nag:
         specifier: ^2.34.23
-        version: 2.34.23(aws-cdk-lib@2.173.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.34.23(aws-cdk-lib@2.173.1(constructs@10.4.2))(constructs@10.4.2)
       esbuild:
         specifier: ^0.24.0
         version: 0.24.0
@@ -1434,8 +1434,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-cdk-lib@2.173.0:
-    resolution: {integrity: sha512-Da1JUwG8eL+chRSB+c2I4dRf54DWe/wmWKj9CBthNdsE9XCB8odyEcMpmgBC+R160o7ioYY2DBsAaKIIRa9XQw==}
+  aws-cdk-lib@2.173.1:
+    resolution: {integrity: sha512-xlbom4s3sbJDoHzIQmvunTufDQoJHQK8PTh653TE3338PysMX3liZ7efET9/FSQn50S2U3nINDGhrMvjkMBoKw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
@@ -1452,8 +1452,8 @@ packages:
       - yaml
       - mime-types
 
-  aws-cdk@2.173.0:
-    resolution: {integrity: sha512-riRGKSo5dzB0MSbdkZwXRC2t//dI220bgEUfVISilcEafBKj+BPzFBd/eNKuP/dEaS31njkCwtYrS7V7/lV4hQ==}
+  aws-cdk@2.173.1:
+    resolution: {integrity: sha512-1KWz6ZPPpBk3LyxE+iR4Gi1bbdY5N6Zj7kx/26jqvavBfZle93vT3M0jlTKI6v/bBtpYsVHTOmPFcq0fg1DfCw==}
     engines: {node: '>= 14.15.0'}
     hasBin: true
 
@@ -5680,7 +5680,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  aws-cdk-lib@2.173.0(constructs@10.4.2):
+  aws-cdk-lib@2.173.1(constructs@10.4.2):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.214
       '@aws-cdk/asset-kubectl-v20': 2.1.3
@@ -5688,7 +5688,7 @@ snapshots:
       '@aws-cdk/cloud-assembly-schema': 38.0.1
       constructs: 10.4.2
 
-  aws-cdk@2.173.0:
+  aws-cdk@2.173.1:
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -5868,16 +5868,16 @@ snapshots:
       - '@aws-cdk/region-info'
       - constructs
 
-  cdk-iam-floyd@0.658.0(aws-cdk-lib@2.173.0(constructs@10.4.2))(constructs@10.4.2):
+  cdk-iam-floyd@0.658.0(aws-cdk-lib@2.173.1(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
       '@udondan/common-substrings': 3.0.2
-      aws-cdk-lib: 2.173.0(constructs@10.4.2)
+      aws-cdk-lib: 2.173.1(constructs@10.4.2)
       constructs: 10.4.2
       regex-parser: 2.3.0
 
-  cdk-nag@2.34.23(aws-cdk-lib@2.173.0(constructs@10.4.2))(constructs@10.4.2):
+  cdk-nag@2.34.23(aws-cdk-lib@2.173.1(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.0(constructs@10.4.2)
+      aws-cdk-lib: 2.173.1(constructs@10.4.2)
       constructs: 10.4.2
 
   chalk@4.1.2:
@@ -7815,9 +7815,9 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  p6-cdk-namer@1.3.1(aws-cdk-lib@2.173.0(constructs@10.4.2))(constructs@10.4.2):
+  p6-cdk-namer@1.3.1(aws-cdk-lib@2.173.1(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.0(constructs@10.4.2)
+      aws-cdk-lib: 2.173.1(constructs@10.4.2)
       constructs: 10.4.2
 
   package-manager-detector@0.2.7: {}
```