### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/node": "22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",
-    "aws-cdk": "2.173.2",
+    "aws-cdk": "2.173.3",
     "cdk-dia": "^0.11.0",
     "cdk-nag": "^2.34.23",
     "esbuild": "^0.24.2",
@@ -29,7 +29,7 @@
   "dependencies": {
     "@aws-sdk/client-organizations": "^3.716.0",
     "@aws-sdk/client-s3": "^3.717.0",
-    "aws-cdk-lib": "2.173.2",
+    "aws-cdk-lib": "2.173.3",
     "aws-lambda": "^1.0.7",
     "aws-sdk": "^2.1692.0",
     "axios": "^1.7.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.717.0
         version: 3.717.0
       aws-cdk-lib:
-        specifier: 2.173.2
-        version: 2.173.2(constructs@10.4.2)
+        specifier: 2.173.3
+        version: 2.173.3(constructs@10.4.2)
       aws-lambda:
         specifier: ^1.0.7
         version: 1.0.7
@@ -28,13 +28,13 @@ importers:
         version: 1.7.9
       cdk-iam-floyd:
         specifier: ^0.658.0
-        version: 0.658.0(aws-cdk-lib@2.173.2(constructs@10.4.2))(constructs@10.4.2)
+        version: 0.658.0(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2)
       constructs:
         specifier: ^10.4.2
         version: 10.4.2
       p6-cdk-namer:
         specifier: ^1.3.1
-        version: 1.3.1(aws-cdk-lib@2.173.2(constructs@10.4.2))(constructs@10.4.2)
+        version: 1.3.1(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2)
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -64,14 +64,14 @@ importers:
         specifier: ^8.18.2
         version: 8.18.2(eslint@9.17.0)(typescript@5.7.2)
       aws-cdk:
-        specifier: 2.173.2
-        version: 2.173.2
+        specifier: 2.173.3
+        version: 2.173.3
       cdk-dia:
         specifier: ^0.11.0
         version: 0.11.0(@aws-cdk/cloud-assembly-schema@38.0.1)(@aws-cdk/cx-api@1.204.0(@aws-cdk/cloud-assembly-schema@38.0.1))(@aws-cdk/region-info@1.204.0)(constructs@10.4.2)
       cdk-nag:
         specifier: ^2.34.23
-        version: 2.34.23(aws-cdk-lib@2.173.2(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.34.23(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2)
       esbuild:
         specifier: ^0.24.2
         version: 0.24.2
@@ -1439,8 +1439,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-cdk-lib@2.173.2:
-    resolution: {integrity: sha512-cL9+z8Pl3VZGoO7BwdsrFAOeud/vSl3at7OvmhihbNprMN15XuFUx/rViAU5OI1m92NbV4NBzYSLbSeCwYLNyw==}
+  aws-cdk-lib@2.173.3:
+    resolution: {integrity: sha512-AarLLLZK07R8SnMo0rrUDlmRuTIkhZpFmxjY2u62jzqALW88VKkEZcC9Yt9i/7yzUHnya7SbC84KTNNfJEVc1A==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
@@ -1457,8 +1457,8 @@ packages:
       - yaml
       - mime-types
 
-  aws-cdk@2.173.2:
-    resolution: {integrity: sha512-qyMU4FoRJdZDUpsOBqyRBALBjf5A2N/MaHKX9iJUkbTET+d+nR07x3ai4TcEES+8pqPFHMTKpQMRDXs9Py/15w==}
+  aws-cdk@2.173.3:
+    resolution: {integrity: sha512-i+PFFA1FRvnOKXwRpTxDNmDKgDMM38ZbGpsX3x883DgX/a7DcEzoZtzjSMo1ZEp34NN4GzHVubjvjr7Ek8CQlA==}
     engines: {node: '>= 14.15.0'}
     hasBin: true
 
@@ -1828,8 +1828,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@1.5.4:
-    resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
+  es-module-lexer@1.6.0:
+    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
 
   es-object-atoms@1.0.0:
     resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
@@ -3111,8 +3111,8 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
-  pkg-types@1.2.1:
-    resolution: {integrity: sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==}
+  pkg-types@1.3.0:
+    resolution: {integrity: sha512-kS7yWjVFCkIw9hqdJBoMxDdzEngmkr5FXeWZZfQ6GoYacjVnsW6l2CcYW/0ThD0vF4LPJgVYnrg4d0uuhwYQbg==}
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -5682,7 +5682,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  aws-cdk-lib@2.173.2(constructs@10.4.2):
+  aws-cdk-lib@2.173.3(constructs@10.4.2):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.216
       '@aws-cdk/asset-kubectl-v20': 2.1.3
@@ -5690,7 +5690,7 @@ snapshots:
       '@aws-cdk/cloud-assembly-schema': 38.0.1
       constructs: 10.4.2
 
-  aws-cdk@2.173.2:
+  aws-cdk@2.173.3:
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -5870,16 +5870,16 @@ snapshots:
       - '@aws-cdk/region-info'
       - constructs
 
-  cdk-iam-floyd@0.658.0(aws-cdk-lib@2.173.2(constructs@10.4.2))(constructs@10.4.2):
+  cdk-iam-floyd@0.658.0(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
       '@udondan/common-substrings': 3.0.2
-      aws-cdk-lib: 2.173.2(constructs@10.4.2)
+      aws-cdk-lib: 2.173.3(constructs@10.4.2)
       constructs: 10.4.2
       regex-parser: 2.3.0
 
-  cdk-nag@2.34.23(aws-cdk-lib@2.173.2(constructs@10.4.2))(constructs@10.4.2):
+  cdk-nag@2.34.23(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.2(constructs@10.4.2)
+      aws-cdk-lib: 2.173.3(constructs@10.4.2)
       constructs: 10.4.2
 
   chalk@4.1.2:
@@ -6144,7 +6144,7 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@1.5.4: {}
+  es-module-lexer@1.6.0: {}
 
   es-object-atoms@1.0.0:
     dependencies:
@@ -7337,7 +7337,7 @@ snapshots:
   local-pkg@0.5.1:
     dependencies:
       mlly: 1.7.3
-      pkg-types: 1.2.1
+      pkg-types: 1.3.0
 
   locate-path@5.0.0:
     dependencies:
@@ -7721,7 +7721,7 @@ snapshots:
     dependencies:
       acorn: 8.14.0
       pathe: 1.1.2
-      pkg-types: 1.2.1
+      pkg-types: 1.3.0
       ufo: 1.5.4
 
   ms@2.1.3: {}
@@ -7825,9 +7825,9 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  p6-cdk-namer@1.3.1(aws-cdk-lib@2.173.2(constructs@10.4.2))(constructs@10.4.2):
+  p6-cdk-namer@1.3.1(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.2(constructs@10.4.2)
+      aws-cdk-lib: 2.173.3(constructs@10.4.2)
       constructs: 10.4.2
 
   package-manager-detector@0.2.8: {}
@@ -7850,7 +7850,7 @@ snapshots:
 
   parse-imports@2.2.1:
     dependencies:
-      es-module-lexer: 1.5.4
+      es-module-lexer: 1.6.0
       slashes: 3.0.12
 
   parse-json@5.2.0:
@@ -7882,7 +7882,7 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  pkg-types@1.2.1:
+  pkg-types@1.3.0:
     dependencies:
       confbox: 0.1.8
       mlly: 1.7.3


### PR DESCRIPTION
Upgrades project dependencies. The following changes were made:
```diff
diff --git a/package.json b/package.json
index 1356af0..0ee0d33 100644
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/node": "22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",
-    "aws-cdk": "2.173.2",
+    "aws-cdk": "2.173.3",
     "cdk-dia": "^0.11.0",
     "cdk-nag": "^2.34.23",
     "esbuild": "^0.24.2",
@@ -29,7 +29,7 @@
   "dependencies": {
     "@aws-sdk/client-organizations": "^3.716.0",
     "@aws-sdk/client-s3": "^3.717.0",
-    "aws-cdk-lib": "2.173.2",
+    "aws-cdk-lib": "2.173.3",
     "aws-lambda": "^1.0.7",
     "aws-sdk": "^2.1692.0",
     "axios": "^1.7.9",
diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
index aff094f..9ba1f1e 100644
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.717.0
         version: 3.717.0
       aws-cdk-lib:
-        specifier: 2.173.2
-        version: 2.173.2(constructs@10.4.2)
+        specifier: 2.173.3
+        version: 2.173.3(constructs@10.4.2)
       aws-lambda:
         specifier: ^1.0.7
         version: 1.0.7
@@ -28,13 +28,13 @@ importers:
         version: 1.7.9
       cdk-iam-floyd:
         specifier: ^0.658.0
-        version: 0.658.0(aws-cdk-lib@2.173.2(constructs@10.4.2))(constructs@10.4.2)
+        version: 0.658.0(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2)
       constructs:
         specifier: ^10.4.2
         version: 10.4.2
       p6-cdk-namer:
         specifier: ^1.3.1
-        version: 1.3.1(aws-cdk-lib@2.173.2(constructs@10.4.2))(constructs@10.4.2)
+        version: 1.3.1(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2)
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -64,14 +64,14 @@ importers:
         specifier: ^8.18.2
         version: 8.18.2(eslint@9.17.0)(typescript@5.7.2)
       aws-cdk:
-        specifier: 2.173.2
-        version: 2.173.2
+        specifier: 2.173.3
+        version: 2.173.3
       cdk-dia:
         specifier: ^0.11.0
         version: 0.11.0(@aws-cdk/cloud-assembly-schema@38.0.1)(@aws-cdk/cx-api@1.204.0(@aws-cdk/cloud-assembly-schema@38.0.1))(@aws-cdk/region-info@1.204.0)(constructs@10.4.2)
       cdk-nag:
         specifier: ^2.34.23
-        version: 2.34.23(aws-cdk-lib@2.173.2(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.34.23(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2)
       esbuild:
         specifier: ^0.24.2
         version: 0.24.2
@@ -1439,8 +1439,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-cdk-lib@2.173.2:
-    resolution: {integrity: sha512-cL9+z8Pl3VZGoO7BwdsrFAOeud/vSl3at7OvmhihbNprMN15XuFUx/rViAU5OI1m92NbV4NBzYSLbSeCwYLNyw==}
+  aws-cdk-lib@2.173.3:
+    resolution: {integrity: sha512-AarLLLZK07R8SnMo0rrUDlmRuTIkhZpFmxjY2u62jzqALW88VKkEZcC9Yt9i/7yzUHnya7SbC84KTNNfJEVc1A==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
@@ -1457,8 +1457,8 @@ packages:
       - yaml
       - mime-types
 
-  aws-cdk@2.173.2:
-    resolution: {integrity: sha512-qyMU4FoRJdZDUpsOBqyRBALBjf5A2N/MaHKX9iJUkbTET+d+nR07x3ai4TcEES+8pqPFHMTKpQMRDXs9Py/15w==}
+  aws-cdk@2.173.3:
+    resolution: {integrity: sha512-i+PFFA1FRvnOKXwRpTxDNmDKgDMM38ZbGpsX3x883DgX/a7DcEzoZtzjSMo1ZEp34NN4GzHVubjvjr7Ek8CQlA==}
     engines: {node: '>= 14.15.0'}
     hasBin: true
 
@@ -1828,8 +1828,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@1.5.4:
-    resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
+  es-module-lexer@1.6.0:
+    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
 
   es-object-atoms@1.0.0:
     resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
@@ -3111,8 +3111,8 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
-  pkg-types@1.2.1:
-    resolution: {integrity: sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==}
+  pkg-types@1.3.0:
+    resolution: {integrity: sha512-kS7yWjVFCkIw9hqdJBoMxDdzEngmkr5FXeWZZfQ6GoYacjVnsW6l2CcYW/0ThD0vF4LPJgVYnrg4d0uuhwYQbg==}
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -5682,7 +5682,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  aws-cdk-lib@2.173.2(constructs@10.4.2):
+  aws-cdk-lib@2.173.3(constructs@10.4.2):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.216
       '@aws-cdk/asset-kubectl-v20': 2.1.3
@@ -5690,7 +5690,7 @@ snapshots:
       '@aws-cdk/cloud-assembly-schema': 38.0.1
       constructs: 10.4.2
 
-  aws-cdk@2.173.2:
+  aws-cdk@2.173.3:
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -5870,16 +5870,16 @@ snapshots:
       - '@aws-cdk/region-info'
       - constructs
 
-  cdk-iam-floyd@0.658.0(aws-cdk-lib@2.173.2(constructs@10.4.2))(constructs@10.4.2):
+  cdk-iam-floyd@0.658.0(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
       '@udondan/common-substrings': 3.0.2
-      aws-cdk-lib: 2.173.2(constructs@10.4.2)
+      aws-cdk-lib: 2.173.3(constructs@10.4.2)
       constructs: 10.4.2
       regex-parser: 2.3.0
 
-  cdk-nag@2.34.23(aws-cdk-lib@2.173.2(constructs@10.4.2))(constructs@10.4.2):
+  cdk-nag@2.34.23(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.2(constructs@10.4.2)
+      aws-cdk-lib: 2.173.3(constructs@10.4.2)
       constructs: 10.4.2
 
   chalk@4.1.2:
@@ -6144,7 +6144,7 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@1.5.4: {}
+  es-module-lexer@1.6.0: {}
 
   es-object-atoms@1.0.0:
     dependencies:
@@ -7337,7 +7337,7 @@ snapshots:
   local-pkg@0.5.1:
     dependencies:
       mlly: 1.7.3
-      pkg-types: 1.2.1
+      pkg-types: 1.3.0
 
   locate-path@5.0.0:
     dependencies:
@@ -7721,7 +7721,7 @@ snapshots:
     dependencies:
       acorn: 8.14.0
       pathe: 1.1.2
-      pkg-types: 1.2.1
+      pkg-types: 1.3.0
       ufo: 1.5.4
 
   ms@2.1.3: {}
@@ -7825,9 +7825,9 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  p6-cdk-namer@1.3.1(aws-cdk-lib@2.173.2(constructs@10.4.2))(constructs@10.4.2):
+  p6-cdk-namer@1.3.1(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.2(constructs@10.4.2)
+      aws-cdk-lib: 2.173.3(constructs@10.4.2)
       constructs: 10.4.2
 
   package-manager-detector@0.2.8: {}
@@ -7850,7 +7850,7 @@ snapshots:
 
   parse-imports@2.2.1:
     dependencies:
-      es-module-lexer: 1.5.4
+      es-module-lexer: 1.6.0
       slashes: 3.0.12
 
   parse-json@5.2.0:
@@ -7882,7 +7882,7 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  pkg-types@1.2.1:
+  pkg-types@1.3.0:
     dependencies:
       confbox: 0.1.8
       mlly: 1.7.3
```