### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/node": "22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",
-    "aws-cdk": "2.173.3",
+    "aws-cdk": "2.173.4",
     "cdk-dia": "^0.11.0",
     "cdk-nag": "^2.34.23",
     "esbuild": "^0.24.2",
@@ -29,7 +29,7 @@
   "dependencies": {
     "@aws-sdk/client-organizations": "^3.716.0",
     "@aws-sdk/client-s3": "^3.717.0",
-    "aws-cdk-lib": "2.173.3",
+    "aws-cdk-lib": "2.173.4",
     "aws-lambda": "^1.0.7",
     "aws-sdk": "^2.1692.0",
     "axios": "^1.7.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.717.0
         version: 3.717.0
       aws-cdk-lib:
-        specifier: 2.173.3
-        version: 2.173.3(constructs@10.4.2)
+        specifier: 2.173.4
+        version: 2.173.4(constructs@10.4.2)
       aws-lambda:
         specifier: ^1.0.7
         version: 1.0.7
@@ -28,13 +28,13 @@ importers:
         version: 1.7.9
       cdk-iam-floyd:
         specifier: ^0.658.0
-        version: 0.658.0(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2)
+        version: 0.658.0(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2)
       constructs:
         specifier: ^10.4.2
         version: 10.4.2
       p6-cdk-namer:
         specifier: ^1.3.1
-        version: 1.3.1(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2)
+        version: 1.3.1(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2)
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -64,14 +64,14 @@ importers:
         specifier: ^8.18.2
         version: 8.18.2(eslint@9.17.0)(typescript@5.7.2)
       aws-cdk:
-        specifier: 2.173.3
-        version: 2.173.3
+        specifier: 2.173.4
+        version: 2.173.4
       cdk-dia:
         specifier: ^0.11.0
         version: 0.11.0(@aws-cdk/cloud-assembly-schema@38.0.1)(@aws-cdk/cx-api@1.204.0(@aws-cdk/cloud-assembly-schema@38.0.1))(@aws-cdk/region-info@1.204.0)(constructs@10.4.2)
       cdk-nag:
         specifier: ^2.34.23
-        version: 2.34.23(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.34.23(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2)
       esbuild:
         specifier: ^0.24.2
         version: 0.24.2
@@ -1324,8 +1324,8 @@ packages:
   '@udondan/common-substrings@3.0.2':
     resolution: {integrity: sha512-Sc8lNnubj2NtH6zj13K8ADohTnwvXBSp6NWV0LDvia/xfIGHvOhKOHjL7AM9+5lVL3LcIHl85mwpn9LYYhyxuw==}
 
-  '@vitest/eslint-plugin@1.1.20':
-    resolution: {integrity: sha512-2eLsgUm+GVOpDfNyH2do//MiNO/WZkXrPi+EjDmXEdUt6Jwnziq4H221L8vJE0aJys+l1FRfSkm4QbaIyDCfBg==}
+  '@vitest/eslint-plugin@1.1.21':
+    resolution: {integrity: sha512-gIpmafm7WSwXGHq413q3fC26+nER5mQtM7Lqi7UusY5bSzeQIJmViC+G6CfPo06U0CfgZ+rt7FPaskpkZ2f6gg==}
     peerDependencies:
       '@typescript-eslint/utils': '>= 8.0'
       eslint: '>= 8.57.0'
@@ -1439,8 +1439,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-cdk-lib@2.173.3:
-    resolution: {integrity: sha512-AarLLLZK07R8SnMo0rrUDlmRuTIkhZpFmxjY2u62jzqALW88VKkEZcC9Yt9i/7yzUHnya7SbC84KTNNfJEVc1A==}
+  aws-cdk-lib@2.173.4:
+    resolution: {integrity: sha512-0reN94TzkWmyVZDDBlYB4qzJUig8wTHEe82YLHlWRUhrU78fT+drVGUr+lYZwwETaZ+8fLdCOl9ULvFNq7iczQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
@@ -1457,8 +1457,8 @@ packages:
       - yaml
       - mime-types
 
-  aws-cdk@2.173.3:
-    resolution: {integrity: sha512-i+PFFA1FRvnOKXwRpTxDNmDKgDMM38ZbGpsX3x883DgX/a7DcEzoZtzjSMo1ZEp34NN4GzHVubjvjr7Ek8CQlA==}
+  aws-cdk@2.173.4:
+    resolution: {integrity: sha512-zgs3xU28VEKIwHwJHu0ZHeoEmwLGnHS2jPCMc2MsIMZu+a7CKyE77Tw6LwJkuuB96BQyqr6xJB3SbeWjXmcFhQ==}
     engines: {node: '>= 14.15.0'}
     hasBin: true
 
@@ -3775,7 +3775,7 @@ snapshots:
       '@stylistic/eslint-plugin': 2.12.1(eslint@9.17.0)(typescript@5.7.2)
       '@typescript-eslint/eslint-plugin': 8.18.2(@typescript-eslint/parser@8.18.2(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0)(typescript@5.7.2)
       '@typescript-eslint/parser': 8.18.2(eslint@9.17.0)(typescript@5.7.2)
-      '@vitest/eslint-plugin': 1.1.20(@typescript-eslint/utils@8.18.2(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0)(typescript@5.7.2)
+      '@vitest/eslint-plugin': 1.1.21(@typescript-eslint/utils@8.18.2(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0)(typescript@5.7.2)
       eslint: 9.17.0
       eslint-config-flat-gitignore: 0.3.0(eslint@9.17.0)
       eslint-flat-config-utils: 0.4.0
@@ -5542,7 +5542,7 @@ snapshots:
 
   '@udondan/common-substrings@3.0.2': {}
 
-  '@vitest/eslint-plugin@1.1.20(@typescript-eslint/utils@8.18.2(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0)(typescript@5.7.2)':
+  '@vitest/eslint-plugin@1.1.21(@typescript-eslint/utils@8.18.2(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0)(typescript@5.7.2)':
     dependencies:
       '@typescript-eslint/utils': 8.18.2(eslint@9.17.0)(typescript@5.7.2)
       eslint: 9.17.0
@@ -5682,7 +5682,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  aws-cdk-lib@2.173.3(constructs@10.4.2):
+  aws-cdk-lib@2.173.4(constructs@10.4.2):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.216
       '@aws-cdk/asset-kubectl-v20': 2.1.3
@@ -5690,7 +5690,7 @@ snapshots:
       '@aws-cdk/cloud-assembly-schema': 38.0.1
       constructs: 10.4.2
 
-  aws-cdk@2.173.3:
+  aws-cdk@2.173.4:
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -5870,16 +5870,16 @@ snapshots:
       - '@aws-cdk/region-info'
       - constructs
 
-  cdk-iam-floyd@0.658.0(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2):
+  cdk-iam-floyd@0.658.0(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
       '@udondan/common-substrings': 3.0.2
-      aws-cdk-lib: 2.173.3(constructs@10.4.2)
+      aws-cdk-lib: 2.173.4(constructs@10.4.2)
       constructs: 10.4.2
       regex-parser: 2.3.0
 
-  cdk-nag@2.34.23(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2):
+  cdk-nag@2.34.23(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.3(constructs@10.4.2)
+      aws-cdk-lib: 2.173.4(constructs@10.4.2)
       constructs: 10.4.2
 
   chalk@4.1.2:
@@ -7825,9 +7825,9 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  p6-cdk-namer@1.3.1(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2):
+  p6-cdk-namer@1.3.1(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.3(constructs@10.4.2)
+      aws-cdk-lib: 2.173.4(constructs@10.4.2)
       constructs: 10.4.2
 
   package-manager-detector@0.2.8: {}


### PR DESCRIPTION
Upgrades project dependencies. The following changes were made:
```diff
diff --git a/package.json b/package.json
index 0ee0d33..29a0e89 100644
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/node": "22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",
-    "aws-cdk": "2.173.3",
+    "aws-cdk": "2.173.4",
     "cdk-dia": "^0.11.0",
     "cdk-nag": "^2.34.23",
     "esbuild": "^0.24.2",
@@ -29,7 +29,7 @@
   "dependencies": {
     "@aws-sdk/client-organizations": "^3.716.0",
     "@aws-sdk/client-s3": "^3.717.0",
-    "aws-cdk-lib": "2.173.3",
+    "aws-cdk-lib": "2.173.4",
     "aws-lambda": "^1.0.7",
     "aws-sdk": "^2.1692.0",
     "axios": "^1.7.9",
diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
index 9ba1f1e..4b5a01f 100644
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.717.0
         version: 3.717.0
       aws-cdk-lib:
-        specifier: 2.173.3
-        version: 2.173.3(constructs@10.4.2)
+        specifier: 2.173.4
+        version: 2.173.4(constructs@10.4.2)
       aws-lambda:
         specifier: ^1.0.7
         version: 1.0.7
@@ -28,13 +28,13 @@ importers:
         version: 1.7.9
       cdk-iam-floyd:
         specifier: ^0.658.0
-        version: 0.658.0(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2)
+        version: 0.658.0(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2)
       constructs:
         specifier: ^10.4.2
         version: 10.4.2
       p6-cdk-namer:
         specifier: ^1.3.1
-        version: 1.3.1(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2)
+        version: 1.3.1(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2)
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -64,14 +64,14 @@ importers:
         specifier: ^8.18.2
         version: 8.18.2(eslint@9.17.0)(typescript@5.7.2)
       aws-cdk:
-        specifier: 2.173.3
-        version: 2.173.3
+        specifier: 2.173.4
+        version: 2.173.4
       cdk-dia:
         specifier: ^0.11.0
         version: 0.11.0(@aws-cdk/cloud-assembly-schema@38.0.1)(@aws-cdk/cx-api@1.204.0(@aws-cdk/cloud-assembly-schema@38.0.1))(@aws-cdk/region-info@1.204.0)(constructs@10.4.2)
       cdk-nag:
         specifier: ^2.34.23
-        version: 2.34.23(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.34.23(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2)
       esbuild:
         specifier: ^0.24.2
         version: 0.24.2
@@ -1324,8 +1324,8 @@ packages:
   '@udondan/common-substrings@3.0.2':
     resolution: {integrity: sha512-Sc8lNnubj2NtH6zj13K8ADohTnwvXBSp6NWV0LDvia/xfIGHvOhKOHjL7AM9+5lVL3LcIHl85mwpn9LYYhyxuw==}
 
-  '@vitest/eslint-plugin@1.1.20':
-    resolution: {integrity: sha512-2eLsgUm+GVOpDfNyH2do//MiNO/WZkXrPi+EjDmXEdUt6Jwnziq4H221L8vJE0aJys+l1FRfSkm4QbaIyDCfBg==}
+  '@vitest/eslint-plugin@1.1.21':
+    resolution: {integrity: sha512-gIpmafm7WSwXGHq413q3fC26+nER5mQtM7Lqi7UusY5bSzeQIJmViC+G6CfPo06U0CfgZ+rt7FPaskpkZ2f6gg==}
     peerDependencies:
       '@typescript-eslint/utils': '>= 8.0'
       eslint: '>= 8.57.0'
@@ -1439,8 +1439,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-cdk-lib@2.173.3:
-    resolution: {integrity: sha512-AarLLLZK07R8SnMo0rrUDlmRuTIkhZpFmxjY2u62jzqALW88VKkEZcC9Yt9i/7yzUHnya7SbC84KTNNfJEVc1A==}
+  aws-cdk-lib@2.173.4:
+    resolution: {integrity: sha512-0reN94TzkWmyVZDDBlYB4qzJUig8wTHEe82YLHlWRUhrU78fT+drVGUr+lYZwwETaZ+8fLdCOl9ULvFNq7iczQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
@@ -1457,8 +1457,8 @@ packages:
       - yaml
       - mime-types
 
-  aws-cdk@2.173.3:
-    resolution: {integrity: sha512-i+PFFA1FRvnOKXwRpTxDNmDKgDMM38ZbGpsX3x883DgX/a7DcEzoZtzjSMo1ZEp34NN4GzHVubjvjr7Ek8CQlA==}
+  aws-cdk@2.173.4:
+    resolution: {integrity: sha512-zgs3xU28VEKIwHwJHu0ZHeoEmwLGnHS2jPCMc2MsIMZu+a7CKyE77Tw6LwJkuuB96BQyqr6xJB3SbeWjXmcFhQ==}
     engines: {node: '>= 14.15.0'}
     hasBin: true
 
@@ -3775,7 +3775,7 @@ snapshots:
       '@stylistic/eslint-plugin': 2.12.1(eslint@9.17.0)(typescript@5.7.2)
       '@typescript-eslint/eslint-plugin': 8.18.2(@typescript-eslint/parser@8.18.2(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0)(typescript@5.7.2)
       '@typescript-eslint/parser': 8.18.2(eslint@9.17.0)(typescript@5.7.2)
-      '@vitest/eslint-plugin': 1.1.20(@typescript-eslint/utils@8.18.2(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0)(typescript@5.7.2)
+      '@vitest/eslint-plugin': 1.1.21(@typescript-eslint/utils@8.18.2(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0)(typescript@5.7.2)
       eslint: 9.17.0
       eslint-config-flat-gitignore: 0.3.0(eslint@9.17.0)
       eslint-flat-config-utils: 0.4.0
@@ -5542,7 +5542,7 @@ snapshots:
 
   '@udondan/common-substrings@3.0.2': {}
 
-  '@vitest/eslint-plugin@1.1.20(@typescript-eslint/utils@8.18.2(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0)(typescript@5.7.2)':
+  '@vitest/eslint-plugin@1.1.21(@typescript-eslint/utils@8.18.2(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0)(typescript@5.7.2)':
     dependencies:
       '@typescript-eslint/utils': 8.18.2(eslint@9.17.0)(typescript@5.7.2)
       eslint: 9.17.0
@@ -5682,7 +5682,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  aws-cdk-lib@2.173.3(constructs@10.4.2):
+  aws-cdk-lib@2.173.4(constructs@10.4.2):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.216
       '@aws-cdk/asset-kubectl-v20': 2.1.3
@@ -5690,7 +5690,7 @@ snapshots:
       '@aws-cdk/cloud-assembly-schema': 38.0.1
       constructs: 10.4.2
 
-  aws-cdk@2.173.3:
+  aws-cdk@2.173.4:
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -5870,16 +5870,16 @@ snapshots:
       - '@aws-cdk/region-info'
       - constructs
 
-  cdk-iam-floyd@0.658.0(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2):
+  cdk-iam-floyd@0.658.0(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
       '@udondan/common-substrings': 3.0.2
-      aws-cdk-lib: 2.173.3(constructs@10.4.2)
+      aws-cdk-lib: 2.173.4(constructs@10.4.2)
       constructs: 10.4.2
       regex-parser: 2.3.0
 
-  cdk-nag@2.34.23(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2):
+  cdk-nag@2.34.23(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.3(constructs@10.4.2)
+      aws-cdk-lib: 2.173.4(constructs@10.4.2)
       constructs: 10.4.2
 
   chalk@4.1.2:
@@ -7825,9 +7825,9 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  p6-cdk-namer@1.3.1(aws-cdk-lib@2.173.3(constructs@10.4.2))(constructs@10.4.2):
+  p6-cdk-namer@1.3.1(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.3(constructs@10.4.2)
+      aws-cdk-lib: 2.173.4(constructs@10.4.2)
       constructs: 10.4.2
 
   package-manager-detector@0.2.8: {}
```