### PR TITLE
fix(ci): restore build.yml trailing newline and renamed build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: CDK Build
-        uses: p6m7g8-actions/cdk-build@main
+        uses: p6m7g8-actions/p6-cdk-build@main
         with:
           aws_region: ${{ secrets.CDK_DEPLOY_REGION }}
           aws_role: ${{ secrets.AWS_ROLE }}


### PR DESCRIPTION
See commit message. Restores the trailing newline yamllint requires, and re-applies the build-action rename that the distribution merge reverted. The queue-ref trigger is preserved.